### PR TITLE
Basic go server configured to receive github webhook events

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ const (
 )
 
 func main() {
-	hook, _ := github.New(github.Options.Secret("thespeedeq!"))
+	hook, _ := github.New(github.Options.Secret("<GITHUBSECRET>"))
 
 	http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		payload, err := hook.Parse(r, github.PushEvent)

--- a/main.go
+++ b/main.go
@@ -11,23 +11,23 @@ const (
 )
 
 func main() {
-	hook, _ := github.New(github.Options.Secret("<GITHUBSECRET>"))
+	hook, err := github.New(github.Options.Secret("<GITHUBSECRET>"))
+	if err != nil {
+		fmt.Println("github.New Error", err)
+	}
 
 	http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		payload, err := hook.Parse(r, github.PushEvent)
 		if err != nil {
-			if err == github.ErrEventNotFound {
-				// ok event wasn't one of the ones asked to be parsed
-				println("Error receiving github payload")
-			}
-			fmt.Println(err)
-		} else {
-			fmt.Printf("Received Payload:\n")
-			push := payload.(github.PushPayload)
-			fmt.Printf("PUSH PAYLOAD:\n %+v", push)
+			fmt.Println("github payload parse failed", err)
+			return
 		}
+		fmt.Println("Received Payload:")
+		push := payload.(github.PushPayload)
+		fmt.Println("PUSH PAYLOAD:")
+		fmt.Println("%+v", push)
 	})
 
-	fmt.Printf("Starting Server...\n")
+	fmt.Println("Starting Server...")
 	http.ListenAndServe(":3069", nil)
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"gopkg.in/go-playground/webhooks.v5/github"
+	"net/http"
+)
+
+const (
+	path = "/payload"
+)
+
+func main() {
+	hook, _ := github.New(github.Options.Secret("thespeedeq!"))
+
+	http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		payload, err := hook.Parse(r, github.PushEvent)
+		if err != nil {
+			if err == github.ErrEventNotFound {
+				// ok event wasn't one of the ones asked to be parsed
+				println("Error receiving github payload")
+				fmt.Println(err)
+
+			}
+		}
+
+		fmt.Printf("Received Payload:\n")
+		push := payload.(github.PushPayload)
+		fmt.Printf("PUSH PAYLOAD:\n %+v", push)
+
+	})
+
+	fmt.Printf("Starting Server...\n")
+	http.ListenAndServe(":3069", nil)
+}

--- a/main.go
+++ b/main.go
@@ -19,15 +19,13 @@ func main() {
 			if err == github.ErrEventNotFound {
 				// ok event wasn't one of the ones asked to be parsed
 				println("Error receiving github payload")
-				fmt.Println(err)
-
 			}
+			fmt.Println(err)
+		} else {
+			fmt.Printf("Received Payload:\n")
+			push := payload.(github.PushPayload)
+			fmt.Printf("PUSH PAYLOAD:\n %+v", push)
 		}
-
-		fmt.Printf("Received Payload:\n")
-		push := payload.(github.PushPayload)
-		fmt.Printf("PUSH PAYLOAD:\n %+v", push)
-
 	})
 
 	fmt.Printf("Starting Server...\n")


### PR DESCRIPTION
Simple go server that listens for events from github. If the event received is of the 'push' type the server vomits the entire JSON payload.